### PR TITLE
Adjust for Similarweb's switch to https

### DIFF
--- a/similarweb/similarweb.py
+++ b/similarweb/similarweb.py
@@ -4,7 +4,7 @@ from . import helpers
 class TrafficClient(object):
     def __init__(self, user_key):
         self.user_key = user_key
-        self.base_url = "http://api.similarweb.com/Site/{0}/v1/"
+        self.base_url = "https://api.similarweb.com/Site/{0}/v1/"
         self.full_url = ""
 
     def traffic(self, url):
@@ -109,7 +109,7 @@ class TrafficClient(object):
 class ContentClient(object):
     def __init__(self, user_key):
         self.user_key = user_key
-        self.base_url = "http://api.similarweb.com/Site/{0}/v2/"
+        self.base_url = "https://api.similarweb.com/Site/{0}/v2/"
         self.full_url = ""
 
     def similar_sites(self, url):
@@ -202,7 +202,7 @@ class ContentClient(object):
 class SourcesClient(object):
     def __init__(self, user_key):
         self.user_key = user_key
-        self.base_url = "http://api.similarweb.com/Site/{0}/{1}/"
+        self.base_url = "https://api.similarweb.com/Site/{0}/{1}/"
         self.full_url = ""
 
     def organic_search_keywords(self, url, page, start, end, md = False):
@@ -327,7 +327,7 @@ class SourcesClient(object):
 class MobileClient(object):
     def __init__(self, user_key):
         self.user_key = user_key
-        self.base_url = "http://api.similarweb.com/Mobile/{0}/{1}/"
+        self.base_url = "https://api.similarweb.com/Mobile/{0}/{1}/"
         self.full_url = ""
 
     def app_details(self, app_id, app_store):

--- a/similarweb/version.py
+++ b/similarweb/version.py
@@ -1,3 +1,3 @@
-__version_info__ = ("0", "3", "1")
+__version_info__ = ("1", "0", "0")
 __version__ = ".".join(__version_info__)
 

--- a/tests/test_content_client.py
+++ b/tests/test_content_client.py
@@ -14,7 +14,7 @@ def test_content_client_has_user_key():
 def test_content_client_has_base_url():
     client = ContentClient("test_key")
 
-    assert client.base_url == "http://api.similarweb.com/Site/{0}/v2/"
+    assert client.base_url == "https://api.similarweb.com/Site/{0}/v2/"
 
 
 def test_content_client_has_empty_full_url():
@@ -25,7 +25,7 @@ def test_content_client_has_empty_full_url():
 
 @httpretty.activate
 def test_content_client_similar_sites_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/similarsites?UserKey=test_key")
     f = "{0}/fixtures/content_client_similar_sites_good_response.json".format(TD)
     with open(f) as data_file:
@@ -40,7 +40,7 @@ def test_content_client_similar_sites_completes_full_url():
 @httpretty.activate
 def test_content_client_similar_sites_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/similarsites?UserKey=invalid_key")
     f = "{0}/fixtures/content_client_similar_sites_invalid_api_key_response.json".format(TD)
     with open(f) as data_file:
@@ -55,7 +55,7 @@ def test_content_client_similar_sites_response_from_invalid_api_key():
 @httpretty.activate
 def test_content_client_similar_sites_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v2/similarsites?UserKey=test_key")
     f = "{0}/fixtures/content_client_similar_sites_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -71,14 +71,14 @@ def test_content_client_similar_sites_response_from_malformed_url():
 @httpretty.activate
 def test_content_client_similar_sites_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v2/similarsites?UserKey=test_key")
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v2/similarsites?UserKey=test_key")
     f = "{0}/fixtures/content_client_similar_sites_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = ContentClient("test_key")
-        result = client.similar_sites("http://example.com")
+        result = client.similar_sites("https://example.com")
 
         assert result == expected
 
@@ -86,7 +86,7 @@ def test_content_client_similar_sites_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_content_client_similar_sites_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/similarsites?UserKey=test_key")
     f = "{0}/fixtures/content_client_similar_sites_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -120,7 +120,7 @@ def test_content_client_similar_sites_response_from_good_inputs():
                 "realgm.com": 0.3262779713759013,
                 "basketball-reference.com": 0.2913301249701222,
                 "82games.com": 0.28480732814372367}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/similarsites?UserKey=test_key")
     f = "{0}/fixtures/content_client_similar_sites_good_response.json".format(TD)
     with open(f) as data_file:
@@ -134,7 +134,7 @@ def test_content_client_similar_sites_response_from_good_inputs():
 
 @httpretty.activate
 def test_content_client_also_visited_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/alsovisited?UserKey=test_key")
     f = "{0}/fixtures/content_client_also_visited_good_response.json".format(TD)
     with open(f) as data_file:
@@ -149,7 +149,7 @@ def test_content_client_also_visited_completes_full_url():
 @httpretty.activate
 def test_content_client_also_visited_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/alsovisited?UserKey=invalid_key")
     f = "{0}/fixtures/content_client_also_visited_invalid_api_key_response.json".format(TD)
     with open(f) as data_file:
@@ -164,7 +164,7 @@ def test_content_client_also_visited_response_from_invalid_api_key():
 @httpretty.activate
 def test_content_client_also_visited_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v2/alsovisited?UserKey=test_key")
     f = "{0}/fixtures/content_client_also_visited_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -180,14 +180,14 @@ def test_content_client_also_visited_response_from_malformed_url():
 @httpretty.activate
 def test_content_client_also_visited_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v2/alsovisited?UserKey=test_key")
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v2/alsovisited?UserKey=test_key")
     f = "{0}/fixtures/content_client_also_visited_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = ContentClient("test_key")
-        result = client.also_visited("http://example.com")
+        result = client.also_visited("https://example.com")
 
         assert result == expected
 
@@ -195,7 +195,7 @@ def test_content_client_also_visited_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_content_client_also_visited_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/alsovisited?UserKey=test_key")
     f = "{0}/fixtures/content_client_also_visited_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -223,7 +223,7 @@ def test_content_client_also_visited_response_from_good_inputs():
                 "scores.espn.go.com": 0.0007570183284250613,
                 "pba.inquirer.net": 0.0004930968059184227,
                 "rotoworld.com": 0.0004921489592139762}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/alsovisited?UserKey=test_key")
     f = "{0}/fixtures/content_client_also_visited_good_response.json".format(TD)
     with open(f) as data_file:
@@ -237,7 +237,7 @@ def test_content_client_also_visited_response_from_good_inputs():
 
 @httpretty.activate
 def test_content_client_tags_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/tags?UserKey=test_key")
     f = "{0}/fixtures/content_client_tags_good_response.json".format(TD)
     with open(f) as data_file:
@@ -252,7 +252,7 @@ def test_content_client_tags_completes_full_url():
 @httpretty.activate
 def test_content_client_tags_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/tags?UserKey=invalid_key")
     f = "{0}/fixtures/content_client_tags_invalid_api_key_response.json".format(TD)
     with open(f) as data_file:
@@ -267,7 +267,7 @@ def test_content_client_tags_response_from_invalid_api_key():
 @httpretty.activate
 def test_content_client_tags_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v2/tags?UserKey=test_key")
     f = "{0}/fixtures/content_client_tags_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -283,14 +283,14 @@ def test_content_client_tags_response_from_malformed_url():
 @httpretty.activate
 def test_content_client_tags_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v2/tags?UserKey=test_key")
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v2/tags?UserKey=test_key")
     f = "{0}/fixtures/content_client_tags_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = ContentClient("test_key")
-        result = client.tags("http://example.com")
+        result = client.tags("https://example.com")
 
         assert result == expected
 
@@ -298,7 +298,7 @@ def test_content_client_tags_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_content_client_tags_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/tags?UserKey=test_key")
     f = "{0}/fixtures/content_client_tags_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -322,7 +322,7 @@ def test_content_client_tags_response_from_good_inputs():
                 "sport": 0.14998747927195202,
                 "leagues": 0.10235439910323241,
                 "imported": 0.09014857846589025}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/tags?UserKey=test_key")
     f = "{0}/fixtures/content_client_tags_good_response.json".format(TD)
     with open(f) as data_file:
@@ -336,7 +336,7 @@ def test_content_client_tags_response_from_good_inputs():
 
 @httpretty.activate
 def test_content_client_category_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/category?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_good_response.json".format(TD)
     with open(f) as data_file:
@@ -351,7 +351,7 @@ def test_content_client_category_completes_full_url():
 @httpretty.activate
 def test_content_client_category_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/category?UserKey=invalid_key")
     f = "{0}/fixtures/content_client_category_invalid_api_key_response.json".format(TD)
     with open(f) as data_file:
@@ -366,7 +366,7 @@ def test_content_client_category_response_from_invalid_api_key():
 @httpretty.activate
 def test_content_client_category_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v2/category?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -382,14 +382,14 @@ def test_content_client_category_response_from_malformed_url():
 @httpretty.activate
 def test_content_client_category_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v2/category?UserKey=test_key")
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v2/category?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = ContentClient("test_key")
-        result = client.category("http://example.com")
+        result = client.category("https://example.com")
 
         assert result == expected
 
@@ -397,7 +397,7 @@ def test_content_client_category_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_content_client_category_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/category?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -412,7 +412,7 @@ def test_content_client_category_response_from_empty_response():
 @httpretty.activate
 def test_content_client_category_response_from_good_inputs():
     expected = {"Category": "Sports/Basketball"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/category?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_good_response.json".format(TD)
     with open(f) as data_file:
@@ -426,7 +426,7 @@ def test_content_client_category_response_from_good_inputs():
 
 @httpretty.activate
 def test_content_client_category_rank_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/categoryrank?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_rank_good_response.json".format(TD)
     with open(f) as data_file:
@@ -441,7 +441,7 @@ def test_content_client_category_rank_completes_full_url():
 @httpretty.activate
 def test_content_client_category_rank_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/categoryrank?UserKey=invalid_key")
     f = "{0}/fixtures/content_client_category_rank_invalid_api_key_response.json".format(TD)
     with open(f) as data_file:
@@ -456,7 +456,7 @@ def test_content_client_category_rank_response_from_invalid_api_key():
 @httpretty.activate
 def test_content_client_category_rank_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v2/categoryrank?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_rank_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -472,14 +472,14 @@ def test_content_client_category_rank_response_from_malformed_url():
 @httpretty.activate
 def test_content_client_category_rank_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v2/categoryrank?UserKey=test_key")
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v2/categoryrank?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_rank_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = ContentClient("test_key")
-        result = client.category_rank("http://example.com")
+        result = client.category_rank("https://example.com")
 
         assert result == expected
 
@@ -487,7 +487,7 @@ def test_content_client_category_rank_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_content_client_category_rank_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/categoryrank?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_rank_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -503,7 +503,7 @@ def test_content_client_category_rank_response_from_empty_response():
 def test_content_client_category_rank_response_from_good_inputs():
     expected = {"Category": "Sports/Basketball",
                 "CategoryRank": 1}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/categoryrank?UserKey=test_key")
     f = "{0}/fixtures/content_client_category_rank_good_response.json".format(TD)
     with open(f) as data_file:

--- a/tests/test_mobile_client.py
+++ b/tests/test_mobile_client.py
@@ -14,7 +14,7 @@ def test_mobile_client_has_user_key():
 def test_mobile_client_has_base_url():
     client = MobileClient("test_key")
 
-    assert client.base_url == "http://api.similarweb.com/Mobile/{0}/{1}/"
+    assert client.base_url == "https://api.similarweb.com/Mobile/{0}/{1}/"
 
 
 def test_mobile_client_has_empty_full_url():
@@ -25,7 +25,7 @@ def test_mobile_client_has_empty_full_url():
 
 @httpretty.activate
 def test_mobile_client_app_details_completes_full_url():
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.yahoo.mobile.client.android.mail/v1/GetAppDetails"
                   "?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_app_details_good_response.json".format(TD)
@@ -49,7 +49,7 @@ def test_mobile_client_app_details_response_from_bad_store():
 @httpretty.activate
 def test_mobile_client_app_details_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.yahoo.mobile.client.android.mail/v1/GetAppDetails"
                   "?UserKey=invalid_key")
     f = "{0}/fixtures/mobile_client_app_details_invalid_api_key_response.json".format(TD)
@@ -72,7 +72,7 @@ def test_mobile_client_app_details_response_from_malformed_app_id():
                 "MainCategory": None,
                 "MainCategoryId": None,
                 "Rating": 0}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.bad_app_id/v1/GetAppDetails?UserKey=invalid_key")
     f = "{0}/fixtures/mobile_client_app_details_malformed_app_id_response.json".format(TD)
     with open(f) as data_file:
@@ -94,7 +94,7 @@ def test_mobile_client_app_details_response_from_oddly_nil_response():
                 "MainCategory": None,
                 "MainCategoryId": None,
                 "Rating": 0}
-    target_url = ("http://api.similarweb.com/Mobile/1/"
+    target_url = ("https://api.similarweb.com/Mobile/1/"
                   "com.clickgamer.angrybirds/v1/"
                   "GetAppDetails?UserKey=invalid_key")
     f = "{0}/fixtures/mobile_client_app_details_oddly_nil_response.json".format(TD)
@@ -111,7 +111,7 @@ def test_mobile_client_app_details_response_from_oddly_nil_response():
 @httpretty.activate
 def test_mobile_client_app_details_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Mobile/1/"
+    target_url = ("https://api.similarweb.com/Mobile/1/"
                   "com.cnn.cnnmoney/v1/GetAppDetails?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_app_details_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -133,7 +133,7 @@ def test_mobile_client_app_details_response_from_good_inputs():
                 "MainCategory": "Communication",
                 "MainCategoryId": "communication",
                 "Rating": 4.186773300170898}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.yahoo.mobile.client.android.mail/v1/"
                   "GetAppDetails?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_app_details_good_response.json".format(TD)
@@ -149,7 +149,7 @@ def test_mobile_client_app_details_response_from_good_inputs():
 
 @httpretty.activate
 def test_mobile_client_google_app_installs_completes_full_url():
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.yahoo.mobile.client.android.mail/v1/GetAppInstalls"
                   "?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_google_app_installs_good_response.json".format(TD)
@@ -165,7 +165,7 @@ def test_mobile_client_google_app_installs_completes_full_url():
 @httpretty.activate
 def test_mobile_client_google_app_installs_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.yahoo.mobile.client.android.mail/v1/GetAppInstalls"
                   "?UserKey=invalid_key")
     f = "{0}/fixtures/mobile_client_google_app_installs_invalid_api_key_response.json".format(TD)
@@ -182,7 +182,7 @@ def test_mobile_client_google_app_installs_response_from_invalid_api_key():
 def test_mobile_client_google_app_installs_response_oddly_nil_response():
     expected = {"InstallsMin": 0,
                 "InstallsMax": 0}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.clickgamer.angrybirds/v1/"
                   "GetAppInstalls?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_google_app_installs_oddly_nil_response.json".format(TD)
@@ -198,7 +198,7 @@ def test_mobile_client_google_app_installs_response_oddly_nil_response():
 @httpretty.activate
 def test_mobile_client_google_app_installs_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "com.cnn.cnnmoney/v1/GetAppInstalls?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_google_app_installs_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -220,7 +220,7 @@ def test_mobile_client_site_related_apps_response_from_bad_store():
 
 @httpretty.activate
 def test_mobile_client_site_related_apps_completes_full_url():
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "google.com/v1/GetRelatedSiteApps?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_site_related_apps_good_response.json".format(TD)
     with open(f) as data_file:
@@ -236,7 +236,7 @@ def test_mobile_client_site_related_apps_completes_full_url():
 @httpretty.activate
 def test_mobile_client_site_related_apps_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "google.com/v1/GetRelatedSiteApps?UserKey=invalid_key")
     f = "{0}/fixtures/mobile_client_site_related_apps_invalid_api_key_response.json".format(TD)
     with open(f) as data_file:
@@ -251,7 +251,7 @@ def test_mobile_client_site_related_apps_response_from_invalid_api_key():
 @httpretty.activate
 def test_mobile_client_site_related_apps_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Mobile/1/"
+    target_url = ("https://api.similarweb.com/Mobile/1/"
                   "bad_url/v1/GetRelatedSiteApps?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_site_related_apps_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -266,7 +266,7 @@ def test_mobile_client_site_related_apps_response_from_malformed_url():
 @httpretty.activate
 def test_mobile_client_site_related_apps_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Mobile/1/"
+    target_url = ("https://api.similarweb.com/Mobile/1/"
                   "apple.com/v1/GetRelatedSiteApps?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_site_related_apps_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -283,7 +283,7 @@ def test_mobile_client_site_related_apps_response_from_good_inputs_google():
     expected = {"com.google.android.youtube": "YouTube",
                 "com.google.android.apps.maps": "Maps",
                 "com.google.android.gms": "Google Play services"}
-    target_url = ("http://api.similarweb.com/Mobile/0/"
+    target_url = ("https://api.similarweb.com/Mobile/0/"
                   "google.com/v1/GetRelatedSiteApps?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_site_related_apps_good_response.json".format(TD)
     with open(f) as data_file:
@@ -300,7 +300,7 @@ def test_mobile_client_site_related_apps_response_from_good_inputs_apple():
     expected = {"284417350": "Remote",
                 "364709193": "iBooks",
                 "376101648": "Find My iPhone"}
-    target_url = ("http://api.similarweb.com/Mobile/1/"
+    target_url = ("https://api.similarweb.com/Mobile/1/"
                   "apple.com/v1/GetRelatedSiteApps?UserKey=test_key")
     f = "{0}/fixtures/mobile_client_site_related_apps_good_apple_response.json".format(TD)
     with open(f) as data_file:

--- a/tests/test_sources_client.py
+++ b/tests/test_sources_client.py
@@ -14,7 +14,7 @@ def test_sources_client_has_user_key():
 def test_sources_client_has_base_url():
     client = SourcesClient("test_key")
 
-    assert client.base_url == "http://api.similarweb.com/Site/{0}/{1}/"
+    assert client.base_url == "https://api.similarweb.com/Site/{0}/{1}/"
 
 
 def test_sources_client_has_empty_full_url():
@@ -25,7 +25,7 @@ def test_sources_client_has_empty_full_url():
 
 @httpretty.activate
 def test_sources_client_social_referrals_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/SocialReferringSites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_social_referrals_good_response.json".format(TD)
@@ -41,7 +41,7 @@ def test_sources_client_social_referrals_completes_full_url():
 @httpretty.activate
 def test_sources_client_social_referrals_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/SocialReferringSites?"
                   "UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_social_referrals_invalid_api_key_response.json".format(TD)
@@ -57,7 +57,7 @@ def test_sources_client_social_referrals_response_from_invalid_api_key():
 @httpretty.activate
 def test_sources_client_social_referrals_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/SocialReferringSites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_social_referrals_url_malformed_response.json".format(TD)
@@ -73,15 +73,15 @@ def test_sources_client_social_referrals_response_from_malformed_url():
 @httpretty.activate
 def test_sources_client_social_referrals_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/SocialReferringSites?"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/SocialReferringSites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_social_referrals_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.social_referrals("http://example.com")
+        result = client.social_referrals("https://example.com")
 
         assert result == expected
 
@@ -89,7 +89,7 @@ def test_sources_client_social_referrals_response_from_malformed_url_incl_http()
 @httpretty.activate
 def test_sources_client_social_referrals_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/SocialReferringSites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_social_referrals_empty_response.json".format(TD)
@@ -112,7 +112,7 @@ def test_sources_client_social_referrals_response_from_good_inputs():
                   "Weibo.com": 0.010782551614770926},
                 "StartDate": "12/2014",
                 "EndDate": "02/2015"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/SocialReferringSites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_social_referrals_good_response.json".format(TD)
@@ -127,7 +127,7 @@ def test_sources_client_social_referrals_response_from_good_inputs():
 
 @httpretty.activate
 def test_sources_client_organic_search_keywords_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_good_response.json".format(TD)
@@ -143,7 +143,7 @@ def test_sources_client_organic_search_keywords_completes_full_url():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_invalid_api_key_response.json".format(TD)
@@ -159,7 +159,7 @@ def test_sources_client_organic_search_keywords_response_from_invalid_api_key():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_url_malformed_response.json".format(TD)
@@ -175,15 +175,15 @@ def test_sources_client_organic_search_keywords_response_from_malformed_url():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/orgsearch?start=11-2014&"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.organic_search_keywords("http://example.com", 1, "11-2014", "12-2014", False)
+        result = client.organic_search_keywords("https://example.com", 1, "11-2014", "12-2014", False)
 
         assert result == expected
 
@@ -191,7 +191,7 @@ def test_sources_client_organic_search_keywords_response_from_malformed_url_incl
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_bad_page():
     expected = {"Error": "The field Page is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=0&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_page_bad_response.json".format(TD)
@@ -207,7 +207,7 @@ def test_sources_client_organic_search_keywords_response_from_bad_page():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=14-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_start_bad_response.json".format(TD)
@@ -223,7 +223,7 @@ def test_sources_client_organic_search_keywords_response_from_bad_start_date():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=11-2014&"
                   "end=0-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_end_bad_response.json".format(TD)
@@ -239,7 +239,7 @@ def test_sources_client_organic_search_keywords_response_from_bad_end_date():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=12-2014&"
                   "end=9-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_out_of_order_response.json".format(TD)
@@ -255,7 +255,7 @@ def test_sources_client_organic_search_keywords_response_out_of_order_dates():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=12-2014&"
                   "end=9-2014&md=other&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_main_domain_bad_response.json".format(TD)
@@ -271,7 +271,7 @@ def test_sources_client_organic_search_keywords_response_from_bad_main_domain():
 @httpretty.activate
 def test_sources_client_organic_search_keywords_response_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_empty_response.json".format(TD)
@@ -319,7 +319,7 @@ def test_sources_client_organic_search_keywords_response_from_good_inputs():
                 "ResultsCount": 10,
                 "TotalCount": 11975,
                 "Next": "http://api.similarweb.com/Site/example.com/v1/orgsearch?start=11-2014&end=12-2014&md=false&UserKey=test_key&page=2"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_search_keywords_good_response.json".format(TD)
@@ -334,7 +334,7 @@ def test_sources_client_organic_search_keywords_response_from_good_inputs():
 
 @httpretty.activate
 def test_sources_client_paid_search_keywords_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_good_response.json".format(TD)
@@ -350,7 +350,7 @@ def test_sources_client_paid_search_keywords_completes_full_url():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_invalid_api_key_response.json".format(TD)
@@ -366,7 +366,7 @@ def test_sources_client_paid_search_keywords_response_from_invalid_api_key():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_url_malformed_response.json".format(TD)
@@ -382,15 +382,15 @@ def test_sources_client_paid_search_keywords_response_from_malformed_url():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/paidsearch?start=11-2014&"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.paid_search_keywords("http://example.com", 1, "11-2014", "12-2014", False)
+        result = client.paid_search_keywords("https://example.com", 1, "11-2014", "12-2014", False)
 
         assert result == expected
 
@@ -398,7 +398,7 @@ def test_sources_client_paid_search_keywords_response_from_malformed_url_incl_ht
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_bad_page():
     expected = {"Error": "The field Page is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=0&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_page_bad_response.json".format(TD)
@@ -414,7 +414,7 @@ def test_sources_client_paid_search_keywords_response_from_bad_page():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=14-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_start_bad_response.json".format(TD)
@@ -430,7 +430,7 @@ def test_sources_client_paid_search_keywords_response_from_bad_start_date():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=11-2014&"
                   "end=0-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_end_bad_response.json".format(TD)
@@ -446,7 +446,7 @@ def test_sources_client_paid_search_keywords_response_from_bad_end_date():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=12-2014&"
                   "end=9-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_out_of_order_response.json".format(TD)
@@ -462,7 +462,7 @@ def test_sources_client_paid_search_keywords_response_out_of_order_dates():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=12-2014&"
                   "end=9-2014&md=other&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_main_domain_bad_response.json".format(TD)
@@ -478,7 +478,7 @@ def test_sources_client_paid_search_keywords_response_from_bad_main_domain():
 @httpretty.activate
 def test_sources_client_paid_search_keywords_response_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_empty_response.json".format(TD)
@@ -526,7 +526,7 @@ def test_sources_client_paid_search_keywords_response_from_good_inputs():
                 "ResultsCount": 10,
                 "TotalCount": 243,
                 "Next": "http://api.similarweb.com/Site/example.com/v1/paidsearch?start=11-2014&end=12-2014&md=false&UserKey=test_key&page=2"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidsearch?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_search_keywords_good_response.json".format(TD)
@@ -541,7 +541,7 @@ def test_sources_client_paid_search_keywords_response_from_good_inputs():
 
 @httpretty.activate
 def test_sources_client_destinations_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/leadingdestinationsites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_destinations_good_response.json".format(TD)
@@ -557,7 +557,7 @@ def test_sources_client_destinations_completes_full_url():
 @httpretty.activate
 def test_sources_client_destinations_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/leadingdestinationsites?"
                   "UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_destinations_invalid_api_key_response.json".format(TD)
@@ -573,7 +573,7 @@ def test_sources_client_destinations_response_from_invalid_api_key():
 @httpretty.activate
 def test_sources_client_destinations_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v2/leadingdestinationsites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_destinations_url_malformed_response.json".format(TD)
@@ -590,15 +590,15 @@ def test_sources_client_destinations_response_from_malformed_url():
 @httpretty.activate
 def test_sources_client_destinations_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v2/leadingdestinationsites?"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v2/leadingdestinationsites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_destinations_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = data_file.read().replace("\n", "")
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.destinations("http://example.com")
+        result = client.destinations("https://example.com")
 
         assert result == expected
 
@@ -606,7 +606,7 @@ def test_sources_client_destinations_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_sources_client_destinations_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/leadingdestinationsites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_destinations_empty_response.json".format(TD)
@@ -633,7 +633,7 @@ def test_sources_client_destinations_response_from_good_inputs():
                           "spox.com"],
                 "StartDate": "12/2014",
                 "EndDate": "02/2015"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v2/leadingdestinationsites?"
                   "UserKey=test_key")
     f = "{0}/fixtures/sources_client_destinations_good_response.json".format(TD)
@@ -648,7 +648,7 @@ def test_sources_client_destinations_response_from_good_inputs():
 
 @httpretty.activate
 def test_sources_client_referrals_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=11-2014&"
                   "end=12-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_good_response.json".format(TD)
@@ -664,7 +664,7 @@ def test_sources_client_referrals_completes_full_url():
 @httpretty.activate
 def test_sources_client_referrals_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=11-2014&"
                   "end=12-2014&page=1&UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_referrals_invalid_api_key_response.json".format(TD)
@@ -680,7 +680,7 @@ def test_sources_client_referrals_response_from_invalid_api_key():
 @httpretty.activate
 def test_sources_client_referrals_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/referrals?start=11-2014&"
                   "end=12-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_url_malformed_response.json".format(TD)
@@ -696,15 +696,15 @@ def test_sources_client_referrals_response_from_malformed_url():
 @httpretty.activate
 def test_sources_client_referrals_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/referrals?start=11-2014&"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/referrals?start=11-2014&"
                   "end=12-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.referrals("http://example.com", 1, "11-2014", "12-2014")
+        result = client.referrals("https://example.com", 1, "11-2014", "12-2014")
 
         assert result == expected
 
@@ -712,7 +712,7 @@ def test_sources_client_referrals_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_sources_client_referrals_response_from_bad_page():
     expected = {"Error": "The field Page is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=11-2014&"
                   "end=12-2014&page=0&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_page_bad_response.json".format(TD)
@@ -728,7 +728,7 @@ def test_sources_client_referrals_response_from_bad_page():
 @httpretty.activate
 def test_sources_client_referrals_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=14-2014&"
                   "end=12-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_start_bad_response.json".format(TD)
@@ -744,7 +744,7 @@ def test_sources_client_referrals_response_from_bad_start_date():
 @httpretty.activate
 def test_sources_client_referrals_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=11-2014&"
                   "end=0-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_end_bad_response.json".format(TD)
@@ -760,7 +760,7 @@ def test_sources_client_referrals_response_from_bad_end_date():
 @httpretty.activate
 def test_sources_client_referrals_response_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=12-2014&"
                   "end=9-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_out_of_order_response.json".format(TD)
@@ -776,7 +776,7 @@ def test_sources_client_referrals_response_out_of_order_dates():
 @httpretty.activate
 def test_sources_client_referrals_response_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=11-2014&"
                   "end=12-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_empty_response.json".format(TD)
@@ -825,7 +825,7 @@ def test_sources_client_referrals_response_from_good_inputs():
                 "ResultsCount": 10,
                 "TotalCount": 1540,
                 "Next": "http://api.similarweb.com/Site/example.com/v1/referrals?start=11-2014&end=12-2014&UserKey=test_key&page=2"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/referrals?start=11-2014&"
                   "end=12-2014&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_referrals_good_response.json".format(TD)
@@ -840,7 +840,7 @@ def test_sources_client_referrals_response_from_good_inputs():
 
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_good_response.json".format(TD)
@@ -856,7 +856,7 @@ def test_sources_client_organic_keyword_competitors_completes_full_url():
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_invalid_api_key_response.json".format(TD)
@@ -872,7 +872,7 @@ def test_sources_client_organic_keyword_competitors_response_from_invalid_api_ke
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_url_malformed_response.json".format(TD)
@@ -888,15 +888,15 @@ def test_sources_client_organic_keyword_competitors_response_from_malformed_url(
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/orgkwcompetitor?start=11-2014&"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.organic_keyword_competitors("http://example.com", 1, "11-2014", "12-2014", False)
+        result = client.organic_keyword_competitors("https://example.com", 1, "11-2014", "12-2014", False)
 
         assert result == expected
 
@@ -904,7 +904,7 @@ def test_sources_client_organic_keyword_competitors_response_from_malformed_url_
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_bad_page():
     expected = {"Error": "The field Page is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=0&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_page_bad_response.json".format(TD)
@@ -920,7 +920,7 @@ def test_sources_client_organic_keyword_competitors_response_from_bad_page():
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=14-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_start_bad_response.json".format(TD)
@@ -936,7 +936,7 @@ def test_sources_client_organic_keyword_competitors_response_from_bad_start_date
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=0-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_end_bad_response.json".format(TD)
@@ -952,7 +952,7 @@ def test_sources_client_organic_keyword_competitors_response_from_bad_end_date()
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=12-2014&"
                   "end=9-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_out_of_order_response.json".format(TD)
@@ -968,7 +968,7 @@ def test_sources_client_organic_keyword_competitors_response_out_of_order_dates(
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=12-2014&"
                   "end=9-2014&md=other&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_main_domain_bad_response.json".format(TD)
@@ -984,7 +984,7 @@ def test_sources_client_organic_keyword_competitors_response_from_bad_main_domai
 @httpretty.activate
 def test_sources_client_organic_keyword_competitors_response_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_empty_response.json".format(TD)
@@ -1011,8 +1011,8 @@ def test_sources_client_organic_keyword_competitors_response_from_good_inputs():
                          "stubhub.com": 0.007999157326624741},
                 "ResultsCount": 10,
                 "TotalCount": 1510,
-                "Next": "http://api.similarweb.com/Site/example.com/v1/orgkwcompetitor?start=11-2014&end=12-2014&md=false&UserKey=test_key&page=2"}
-    target_url = ("http://api.similarweb.com/Site/"
+                "Next": "https://api.similarweb.com/Site/example.com/v1/orgkwcompetitor?start=11-2014&end=12-2014&md=false&UserKey=test_key&page=2"}
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/orgkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_organic_keyword_competitors_good_response.json".format(TD)
@@ -1028,7 +1028,7 @@ def test_sources_client_organic_keyword_competitors_response_from_good_inputs():
 
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_good_response.json".format(TD)
@@ -1044,7 +1044,7 @@ def test_sources_client_paid_keyword_competitors_completes_full_url():
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=invalid_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_invalid_api_key_response.json".format(TD)
@@ -1060,7 +1060,7 @@ def test_sources_client_paid_keyword_competitors_response_from_invalid_api_key()
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_url_malformed_response.json".format(TD)
@@ -1076,15 +1076,15 @@ def test_sources_client_paid_keyword_competitors_response_from_malformed_url():
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/paidkwcompetitor?start=11-2014&"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = SourcesClient("test_key")
-        result = client.paid_keyword_competitors("http://example.com", 1, "11-2014", "12-2014", False)
+        result = client.paid_keyword_competitors("https://example.com", 1, "11-2014", "12-2014", False)
 
         assert result == expected
 
@@ -1092,7 +1092,7 @@ def test_sources_client_paid_keyword_competitors_response_from_malformed_url_inc
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_bad_page():
     expected = {"Error": "The field Page is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=0&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_page_bad_response.json".format(TD)
@@ -1108,7 +1108,7 @@ def test_sources_client_paid_keyword_competitors_response_from_bad_page():
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=14-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_start_bad_response.json".format(TD)
@@ -1124,7 +1124,7 @@ def test_sources_client_paid_keyword_competitors_response_from_bad_start_date():
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=0-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_end_bad_response.json".format(TD)
@@ -1140,7 +1140,7 @@ def test_sources_client_paid_keyword_competitors_response_from_bad_end_date():
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=12-2014&"
                   "end=9-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_out_of_order_response.json".format(TD)
@@ -1156,7 +1156,7 @@ def test_sources_client_paid_keyword_competitors_response_out_of_order_dates():
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=12-2014&"
                   "end=9-2014&md=other&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_main_domain_bad_response.json".format(TD)
@@ -1172,7 +1172,7 @@ def test_sources_client_paid_keyword_competitors_response_from_bad_main_domain()
 @httpretty.activate
 def test_sources_client_paid_keyword_competitors_response_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_empty_response.json".format(TD)
@@ -1199,8 +1199,8 @@ def test_sources_client_paid_keyword_competitors_response_from_good_inputs():
                          "vividseats.com": 0.016849267072753825},
                 "ResultsCount": 10,
                 "TotalCount": 489,
-                "Next": "http://api.similarweb.com/Site/example.com/v1/paidkwcompetitor?start=11-2014&end=12-2014&md=false&UserKey=test_key&page=2"}
-    target_url = ("http://api.similarweb.com/Site/"
+                "Next": "https://api.similarweb.com/Site/example.com/v1/paidkwcompetitor?start=11-2014&end=12-2014&md=false&UserKey=test_key&page=2"}
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/paidkwcompetitor?start=11-2014&"
                   "end=12-2014&md=False&page=1&UserKey=test_key")
     f = "{0}/fixtures/sources_client_paid_keyword_competitors_good_response.json".format(TD)

--- a/tests/test_traffic_client.py
+++ b/tests/test_traffic_client.py
@@ -14,7 +14,7 @@ def test_traffic_client_has_user_key():
 def test_traffic_client_has_base_url():
     client = TrafficClient("test_key")
 
-    assert client.base_url == "http://api.similarweb.com/Site/{0}/v1/"
+    assert client.base_url == "https://api.similarweb.com/Site/{0}/v1/"
 
 
 def test_traffic_client_has_empty_full_url():
@@ -25,7 +25,7 @@ def test_traffic_client_has_empty_full_url():
 
 @httpretty.activate
 def test_traffic_client_visits_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_visits_good_response.json".format(TD)
@@ -41,7 +41,7 @@ def test_traffic_client_visits_completes_full_url():
 @httpretty.activate
 def test_traffic_client_visits_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=invalid_key")
@@ -59,7 +59,7 @@ def test_traffic_client_visits_response_from_invalid_api_key():
 @httpretty.activate
 def test_traffic_client_visits_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/visits?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -77,8 +77,8 @@ def test_traffic_client_visits_response_from_malformed_url():
 @httpretty.activate
 def test_traffic_client_visits_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/visits?gr=monthly"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/visits?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_visits_url_with_http_response.json".format(TD)
@@ -86,7 +86,7 @@ def test_traffic_client_visits_response_from_malformed_url_incl_http():
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = TrafficClient("test_key")
-        result = client.visits("http://example.com", "monthly",
+        result = client.visits("https://example.com", "monthly",
                                "11-2014", "12-2014", False)
 
         assert result == expected
@@ -95,7 +95,7 @@ def test_traffic_client_visits_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_traffic_client_visits_response_from_bad_granularity():
     expected = {"Error": "The field Gr is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=bad"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -113,7 +113,7 @@ def test_traffic_client_visits_response_from_bad_granularity():
 @httpretty.activate
 def test_traffic_client_visits_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=14-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -131,7 +131,7 @@ def test_traffic_client_visits_response_from_bad_start_date():
 @httpretty.activate
 def test_traffic_client_visits_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=11-2014&end=0-2014"
                   "&md=False&UserKey=test_key")
@@ -149,7 +149,7 @@ def test_traffic_client_visits_response_from_bad_end_date():
 @httpretty.activate
 def test_traffic_client_visits_response_from_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=12-2014&end=9-2014"
                   "&md=False&UserKey=test_key")
@@ -167,7 +167,7 @@ def test_traffic_client_visits_response_from_out_of_order_dates():
 @httpretty.activate
 def test_traffic_client_visits_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=other&UserKey=test_key")
@@ -185,7 +185,7 @@ def test_traffic_client_visits_response_from_bad_main_domain():
 @httpretty.activate
 def test_traffic_client_visits_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -203,7 +203,7 @@ def test_traffic_client_visits_response_from_empty_response():
 @httpretty.activate
 def test_traffic_client_visits_response_from_good_inputs():
     expected = {"2014-11-01": 12897241, "2014-12-01": 13917811}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visits?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -220,7 +220,7 @@ def test_traffic_client_visits_response_from_good_inputs():
 
 @httpretty.activate
 def test_traffic_client_traffic_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/traffic?UserKey=test_key")
     f = "{0}/fixtures/traffic_client_traffic_good_response.json".format(TD)
     with open(f) as data_file:
@@ -235,7 +235,7 @@ def test_traffic_client_traffic_completes_full_url():
 @httpretty.activate
 def test_traffic_client_traffic_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/traffic?UserKey=invalid_key")
     f = "{0}/fixtures/traffic_client_traffic_invalid_user_key_response.json".format(TD)
     with open(f) as data_file:
@@ -250,7 +250,7 @@ def test_traffic_client_traffic_response_from_invalid_api_key():
 @httpretty.activate
 def test_traffic_client_traffic_response_from_bad_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/traffic?UserKey=test_key")
     f = "{0}/fixtures/traffic_client_traffic_url_malformed_response.json".format(TD)
     with open(f) as data_file:
@@ -265,14 +265,14 @@ def test_traffic_client_traffic_response_from_bad_url():
 @httpretty.activate
 def test_traffic_client_traffic_response_from_bad_url_with_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/traffic?UserKey=test_key")
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/traffic?UserKey=test_key")
     f = "{0}/fixtures/traffic_client_traffic_url_with_http_response.json".format(TD)
     with open(f) as data_file:
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = TrafficClient("test_key")
-        result = client.traffic("http://example.com")
+        result = client.traffic("https://example.com")
 
         assert result == expected
 
@@ -280,7 +280,7 @@ def test_traffic_client_traffic_response_from_bad_url_with_http():
 @httpretty.activate
 def test_traffic_client_traffic_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/traffic?UserKey=test_key")
     f = "{0}/fixtures/traffic_client_traffic_empty_response.json".format(TD)
     with open(f) as data_file:
@@ -316,7 +316,7 @@ def test_traffic_client_traffic_from_good_inputs():
                     "Direct": 0.6771397777323854,
                     "Referrals": 0.1826220905273533},
                 "Date": "01/2015"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/traffic?UserKey=test_key")
     f = "{0}/fixtures/traffic_client_traffic_good_response.json".format(TD)
     with open(f) as data_file:
@@ -330,7 +330,7 @@ def test_traffic_client_traffic_from_good_inputs():
 
 @httpretty.activate
 def test_traffic_client_page_views_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly&start=11-2014"
                   "&end=12-2014&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_page_views_good_response.json".format(TD)
@@ -346,7 +346,7 @@ def test_traffic_client_page_views_completes_full_url():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=invalid_key")
@@ -364,7 +364,7 @@ def test_traffic_client_page_views_response_from_invalid_api_key():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -382,8 +382,8 @@ def test_traffic_client_page_views_response_from_malformed_url():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/pageviews?gr=monthly"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_page_views_url_with_http_response.json".format(TD)
@@ -391,7 +391,7 @@ def test_traffic_client_page_views_response_from_malformed_url_incl_http():
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = TrafficClient("test_key")
-        result = client.page_views("http://example.com", "monthly",
+        result = client.page_views("https://example.com", "monthly",
                                    "11-2014", "12-2014", False)
 
         assert result == expected
@@ -400,7 +400,7 @@ def test_traffic_client_page_views_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_bad_granularity():
     expected = {"Error": "The field Gr is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=bad"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -418,7 +418,7 @@ def test_traffic_client_page_views_response_from_bad_granularity():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=14-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -436,7 +436,7 @@ def test_traffic_client_page_views_response_from_bad_start_date():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=0-2014"
                   "&md=False&UserKey=test_key")
@@ -454,7 +454,7 @@ def test_traffic_client_page_views_response_from_bad_end_date():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=12-2014&end=9-2014"
                   "&md=False&UserKey=test_key")
@@ -472,7 +472,7 @@ def test_traffic_client_page_views_response_from_out_of_order_dates():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=other&UserKey=test_key")
@@ -490,7 +490,7 @@ def test_traffic_client_page_views_response_from_bad_main_domain():
 @httpretty.activate
 def test_traffic_client_page_views_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -509,7 +509,7 @@ def test_traffic_client_page_views_response_from_empty_response():
 def test_traffic_client_page_views_response_from_good_inputs():
     expected = {"2014-11-01": 14.722378910549942,
                 "2014-12-01": 14.23604875567647}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/pageviews?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -526,7 +526,7 @@ def test_traffic_client_page_views_response_from_good_inputs():
 
 @httpretty.activate
 def test_traffic_client_visit_duration_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly&start=11-2014"
                   "&end=12-2014&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_visit_duration_good_response.json".format(TD)
@@ -543,7 +543,7 @@ def test_traffic_client_visit_duration_completes_full_url():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=invalid_key")
@@ -561,7 +561,7 @@ def test_traffic_client_visit_duration_response_from_invalid_api_key():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -579,8 +579,8 @@ def test_traffic_client_visit_duration_response_from_malformed_url():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/visitduration?gr=monthly"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_visit_duration_url_with_http_response.json".format(TD)
@@ -588,7 +588,7 @@ def test_traffic_client_visit_duration_response_from_malformed_url_incl_http():
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = TrafficClient("test_key")
-        result = client.visit_duration("http://example.com", "monthly",
+        result = client.visit_duration("https://example.com", "monthly",
                                        "11-2014", "12-2014", False)
 
         assert result == expected
@@ -597,7 +597,7 @@ def test_traffic_client_visit_duration_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_bad_granularity():
     expected = {"Error": "The field Gr is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=bad"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -615,7 +615,7 @@ def test_traffic_client_visit_duration_response_from_bad_granularity():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=14-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -633,7 +633,7 @@ def test_traffic_client_visit_duration_response_from_bad_start_date():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=0-2014"
                   "&md=False&UserKey=test_key")
@@ -651,7 +651,7 @@ def test_traffic_client_visit_duration_response_from_bad_end_date():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=12-2014&end=9-2014"
                   "&md=False&UserKey=test_key")
@@ -669,7 +669,7 @@ def test_traffic_client_visit_duration_response_from_out_of_order_dates():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=other&UserKey=test_key")
@@ -687,7 +687,7 @@ def test_traffic_client_visit_duration_response_from_bad_main_domain():
 @httpretty.activate
 def test_traffic_client_visit_duration_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -706,7 +706,7 @@ def test_traffic_client_visit_duration_response_from_empty_response():
 def test_traffic_client_visit_duration_response_from_good_inputs():
     expected = {"2014-11-01": 971.0572442455453,
                 "2014-12-01": 961.5564560783813}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/visitduration?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -723,7 +723,7 @@ def test_traffic_client_visit_duration_response_from_good_inputs():
 
 @httpretty.activate
 def test_traffic_client_bounce_rate_completes_full_url():
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly&start=11-2014"
                   "&end=12-2014&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_bounce_rate_good_response.json".format(TD)
@@ -740,7 +740,7 @@ def test_traffic_client_bounce_rate_completes_full_url():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_invalid_api_key():
     expected = {"Error": "user_key_invalid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=invalid_key")
@@ -758,7 +758,7 @@ def test_traffic_client_bounce_rate_response_from_invalid_api_key():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_malformed_url():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "bad_url/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -776,8 +776,8 @@ def test_traffic_client_bounce_rate_response_from_malformed_url():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_malformed_url_incl_http():
     expected = {"Error": "Malformed or Unknown URL"}
-    target_url = ("http://api.similarweb.com/Site/"
-                  "http://example.com/v1/bouncerate?gr=monthly"
+    target_url = ("https://api.similarweb.com/Site/"
+                  "https://example.com/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
     f = "{0}/fixtures/traffic_client_bounce_rate_url_with_http_response.json".format(TD)
@@ -785,7 +785,7 @@ def test_traffic_client_bounce_rate_response_from_malformed_url_incl_http():
         stringified = json.dumps(json.load(data_file))
         httpretty.register_uri(httpretty.GET, target_url, body=stringified)
         client = TrafficClient("test_key")
-        result = client.bounce_rate("http://example.com", "monthly",
+        result = client.bounce_rate("https://example.com", "monthly",
                                     "11-2014", "12-2014", False)
 
         assert result == expected
@@ -794,7 +794,7 @@ def test_traffic_client_bounce_rate_response_from_malformed_url_incl_http():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_bad_granularity():
     expected = {"Error": "The field Gr is invalid."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=bad"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -812,7 +812,7 @@ def test_traffic_client_bounce_rate_response_from_bad_granularity():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_bad_start_date():
     expected = {"Error": "The value '14-2014' is not valid for Start."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=14-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -830,7 +830,7 @@ def test_traffic_client_bounce_rate_response_from_bad_start_date():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_bad_end_date():
     expected = {"Error": "The value '0-2014' is not valid for End."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=0-2014"
                   "&md=False&UserKey=test_key")
@@ -848,7 +848,7 @@ def test_traffic_client_bounce_rate_response_from_bad_end_date():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_out_of_order_dates():
     expected = {"Error": "Date range is not valid"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=12-2014&end=9-2014"
                   "&md=False&UserKey=test_key")
@@ -866,7 +866,7 @@ def test_traffic_client_bounce_rate_response_from_out_of_order_dates():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_bad_main_domain():
     expected = {"Error": "The value 'other' is not valid for Md."}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=other&UserKey=test_key")
@@ -884,7 +884,7 @@ def test_traffic_client_bounce_rate_response_from_bad_main_domain():
 @httpretty.activate
 def test_traffic_client_bounce_rate_response_from_empty_response():
     expected = {"Error": "Unknown Error"}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")
@@ -903,7 +903,7 @@ def test_traffic_client_bounce_rate_response_from_empty_response():
 def test_traffic_client_bounce_rate_response_from_good_inputs():
     expected = {"2014-11-01": 0.21914567903351953,
                 "2014-12-01": 0.22588292927510623}
-    target_url = ("http://api.similarweb.com/Site/"
+    target_url = ("https://api.similarweb.com/Site/"
                   "example.com/v1/bouncerate?gr=monthly"
                   "&start=11-2014&end=12-2014"
                   "&md=False&UserKey=test_key")


### PR DESCRIPTION
The Similarweb team has made the switch from "http" to "https" -- this PR adjusts URL-formation to account for that and prevent unresolved 301s.